### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Specify a callback to fire once the code has been entered:
 You can personalize the code too, just entering a array with ASCII codes keys in code param
 ```
   $( window ).konami({
-  		code : [38,38,40,40,37,39,37,39] // up up down down left left right right
+  		code : [38,38,40,40,37,39,37,39], // up up down down left left right right
 		cheat: function() {
 			alert( 'Cheat code activated!' );
 		}


### PR DESCRIPTION
The example code was missing a comma, causing the runtime to break if a developer tried to directly copy it.
