### PR TITLE
Fixing example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Specify a callback to fire once the code has been entered:
 You can personalize the code too, just entering a array with ASCII codes keys in code param
 ```
   $( window ).konami({
-  		code : [38,38,40,40,37,39,37,39], // up up down down left left right right
+  		code : [38,38,40,40,37,39,37,39], // up up down down left right left right
 		cheat: function() {
 			alert( 'Cheat code activated!' );
 		}


### PR DESCRIPTION
Fix the example comment since 37=left and 39=right.

Sorry Tom, I meant to quickly sneak this change into the previous pull request, but you grabbed it already :)
