### PR TITLE
Adding jQuery events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Using the Konami code, easily configure and Easter Egg for your page or any elem
 
 * `code` Personalized code.
 * `cheat` The callback function to fire once the cheat code has been entered.
+* `eventName` jQuery event name for default callback
+* `eventProperties` event property override for default callback
 
 ## Installation
 ```
@@ -24,9 +26,17 @@ Include the plugin in the header of your page:
 	<script src="jquery.konami.js" type="text/javascript"></script>
 ```
 
-Apply the plugin to the window to capture keypresses:
+### With callback
 
-`$( window ).konami();`
+Apply the plugin to a selector to capture keypresses:
+
+```
+  $( window ).konami();
+```
+
+```
+  $( '.konami-sensitive' ).konami();
+```
 
 Specify a callback to fire once the code has been entered:
 
@@ -38,7 +48,40 @@ Specify a callback to fire once the code has been entered:
 	});
 ```
 
+### Using jQuery events
+
+Catch the konami code with a jQuery event handler:
+
+```
+  $( window ).konami();
+  $( window ).on('konami', function() {
+    alert( 'Cheat code activated!' );
+  })
+```
+
+Add extra data to the jQuery event callback:
+
+```
+  $( window ).konami( { message: 'special message' } );
+  $( window ).on('konami', function(evt, extraParam) {
+    alert( 'Cheat code activated: ' + extraParam.message + '!' );
+  })
+```
+
+Use event names:
+
+```
+  $('.type1').konami( { eventName: 'konami.on.type1' } );
+  $('.type2').konami( { eventName: 'konami.on.type2' } );
+  $( window ).on('konami.on.type2', function(evt, extraParam) {
+    alert( 'Cheat code activated on a type2 element' );
+  })
+```
+
+### Personallizing the code
+
 You can personalize the code too, just entering a array with ASCII codes keys in code param
+
 ```
   $( window ).konami({
   		code : [38,38,40,40,37,39,37,39], // up up down down left right left right

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
+_1.3.1_
+
+* jQuery events supported
+
 _1.3.0 (7 March 2014)_
+
 * Minor updates to the coding conventions and docblocks
 * Tagging for registration in the Bower repository
 

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -2,13 +2,30 @@
 <html>
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-		<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-		<script type="text/javascript" src="../src/jquery.konami.min.js"></script>
+		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+		<script type="text/javascript" src="../src/jquery.konami.js"></script>
 		<script type="text/javascript" src="demo.js"></script>
 		<title>Konami Code For jQuery | Demo</title>
 	</head>
 	<body>
 		<h1>Enter the Konami Code</h1>
-		<h2>[up up down down left right left right b a]
+		<h2>[up up down down left right left right b a]</h2>
+
+		Four konami code event handlers are attached to this window.
+		<ul>
+		<li>A global handler is attached to the window.</li>
+		<li>A handler is attached to input 1.</li>
+		<li>A handler is attached to input 2.</li>
+		<li>A handler is attached to odd-numbered inputs (1&3).</li>
+		</ul>
+		
+		When you enter the komami code while the caret is in input1, you should see three alerts.
+		
+		<form id="form1">
+			Input 1: <input type='text' id="input1" class="odd"/><br/>
+			Input 2: <input type='text' id="input2" class="even"/><br/>
+			Input 3: <input type='text' id="input3" class="odd"/><br/>
+		</form>
+		
 	</body>
 </html>

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -2,14 +2,19 @@
 	"use strict";
 
 	$(function() {
-
 		$( window ).konami({
-
 			cheat: function() {
 				alert( 'Cheat code activated!' );
 			} // end cheat
-
 		});
-
+		
+		$('#input1').konami( { eventName: 'konami.with.message', message: 'Code on Input 1' } );
+		$('#input2').konami( { eventName: 'konami.with.message', message: 'Code on Input 2' } );
+		$('.odd').konami( { eventName: 'konami.with.message', message: 'Code on an odd-numbered input' } );
+	
+		$(window).on('konami.with.message', function(event, opts) {
+			alert('Cheat code with message: ' + opts.message);
+		});
 	});
 }(jQuery));
+

--- a/src/jquery.konami.js
+++ b/src/jquery.konami.js
@@ -12,41 +12,43 @@
 	"use strict";
 
 	$.fn.konami = function( options ) {
-
-		var opts, masterKey, controllerCode, code;
+		var opts, controllerCode;
+		
 		opts = $.extend({}, $.fn.konami.defaults, options);
+		controllerCode = [];
+		
+		// note that we use the passed-in options, not the resolved options
+		opts.eventProperties = $.extend({}, options,  opts.eventProperties);
+		
+		this.keyup(function( evt ) {
+			var code = evt.keyCode || evt.which;
 
-		return this.each(function() {
+			if ( opts.code.length > controllerCode.push( code ) ) {
+				return;
+			} // end if
 
-			controllerCode = [];
+			if ( opts.code.length < controllerCode.length ) {
+				controllerCode.shift();
+			} // end if
 
-			$( window ).keyup(function( evt ) {
+			if ( opts.code.toString() !== controllerCode.toString() ) {
+				return;
+			} // end if
 
-				code = evt.keyCode || evt.which;
+			opts.cheat(evt, opts);
 
-				if ( opts.code.length > controllerCode.push( code ) ) {
-					return;
-				} // end if
-
-				if ( opts.code.length < controllerCode.length ) {
-					controllerCode.shift();
-				} // end if
-
-				if ( opts.code.toString() !== controllerCode.toString() ) {
-					return;
-				} // end for
-
-				opts.cheat();
-
-			}); // end keyup
-
-		}); // end each
-
+		}); // end keyup
+		
+		return this;
 	}; // end opts
 
 	$.fn.konami.defaults = {
 		code : [38,38,40,40,37,39,37,39,66,65],
-		cheat: null
+		eventName : 'konami',
+		eventProperties : null,
+		cheat: function(evt, opts) {
+			$(evt.target).trigger(opts.eventName, [ opts.eventProperties ]);
+		}
 	};
 
 }( jQuery ));

--- a/src/jquery.konami.min.js
+++ b/src/jquery.konami.min.js
@@ -6,4 +6,5 @@
  *
  * Copyright 2011 - 2014 Tom McFarlin, http://tommcfarlin.com
  * Released under the MIT License
- */(function(e){"use strict";e.fn.konami=function(t){var n,r,i,s;n=e.extend({},e.fn.konami.defaults,t);return this.each(function(){i=[];e(window).keyup(function(e){s=e.keyCode||e.which;if(n.code.length>i.push(s)){return}if(n.code.length<i.length){i.shift()}if(n.code.toString()!==i.toString()){return}n.cheat()})})};e.fn.konami.defaults={code:[38,38,40,40,37,39,37,39,66,65],cheat:null}})(jQuery)
+ */
+!function(e){"use strict";e.fn.konami=function(t){var n,i;return n=e.extend({},e.fn.konami.defaults,t),i=[],n.eventProperties=e.extend({},t,n.eventProperties),this.keyup(function(e){var t=e.keyCode||e.which;n.code.length>i.push(t)||(n.code.length<i.length&&i.shift(),""+n.code==""+i&&n.cheat(e,n))}),this},e.fn.konami.defaults={code:[38,38,40,40,37,39,37,39,66,65],eventName:"konami",eventProperties:null,cheat:function(t,n){e(t.target).trigger(n.eventName,[n.eventProperties])}}}(jQuery);


### PR DESCRIPTION
I have added some code to fire jquery events when the konami code happens. This is implemented by including a default cheat function, and by passing the event and the options to that cheat function.

To control multiple jquery events being fired, the keyUp event handler is attached once to the selector, rather than being attached separately to each element with .each() . For the most usual case - adding a handler to the window - this will not affect things.

I have not done this fork/pull thing with someone else's code on github before, so I was unsure if it was my job to increment the version numbers and whatnot in the various documentation files so I left the alone.
